### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/.vim/bundle/syntastic/doc/syntastic-checkers.txt
+++ b/.vim/bundle/syntastic/doc/syntastic-checkers.txt
@@ -1756,7 +1756,7 @@ Maintainer:  LCD 47 <lcd047@gmail.com>
 "PHP_CodeSniffer" is a style linter for PHP and CSS. See the project's page
 at GitHub for details:
 
-    https://github.com/squizlabs/PHP_CodeSniffer/
+    https://github.com/PHPCSStandards/PHP_CodeSniffer/
 
 Installation~
 
@@ -4766,7 +4766,7 @@ Maintainer:  Martin Grenfell <martin.grenfell@gmail.com>
 "PHP_CodeSniffer" is a style linter for PHP and CSS. See the project's page
 at GitHub for details:
 
-    https://github.com/squizlabs/PHP_CodeSniffer/
+    https://github.com/PHPCSStandards/PHP_CodeSniffer/
 
 Installation~
 

--- a/README.md
+++ b/README.md
@@ -186,4 +186,4 @@ There's a bash function called `create-ctags` that may be called in project dire
 - various dotfiles of other people (e.g. bash functions `calc`, `json`, `gz`, `unidecode`, `escape` from @mathiasbynens)
 - [`bin/git-open`](https://github.com/paulirish/git-open)
 - [`bin/twig-lint`](https://github.com/asm89/twig-lint)
-- [`bin/phpcs`](https://github.com/squizlabs/PHP_CodeSniffer)
+- [`bin/phpcs`](https://github.com/PHPCSStandards/PHP_CodeSniffer)


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932